### PR TITLE
Fixs error while tapping

### DIFF
--- a/Formula/terrafile.rb
+++ b/Formula/terrafile.rb
@@ -3,7 +3,6 @@ class Terrafile < Formula
   desc "Systematically manage external modules from Github for use in Terraform."
   homepage "https://github.com/coretech/terrafile"
   version "0.6"
-  bottle :unneeded
 
   if OS.mac?
     url "https://github.com/coretech/terrafile/releases/download/v0.6/terrafile_0.6_Darwin_x86_64.tar.gz"


### PR DESCRIPTION
Issue: tapping this formulae fails with error "Calling bottle :unneeded is disabled!"

Reason: bottle flags were deprecated on brew core on June 2021 (https://github.com/Homebrew/brew/pull/11239)

Fix: remove the bottle line

Test: locally with modified file (`brew install ./terrafile.rb`) and worked just fine.